### PR TITLE
Convert to Async package (removing deprecated API warning)

### DIFF
--- a/ShelvesetComparer/Properties/AssemblyInfo.cs
+++ b/ShelvesetComparer/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(false)]
 [assembly: NeutralResourcesLanguage("en-US")]
 
-[assembly: AssemblyVersion("1.0.0.1")]
-[assembly: AssemblyFileVersion("1.0.0.1")]
+[assembly: AssemblyVersion("1.0.2.19")]
+[assembly: AssemblyFileVersion("1.0.2.19")]

--- a/ShelvesetComparer/Properties/AssemblyInfo.cs
+++ b/ShelvesetComparer/Properties/AssemblyInfo.cs
@@ -1,4 +1,12 @@
 ﻿// <copyright file="AssemblyInfo.cs" company="http://shelvesetcomparer.codeplex.com">Copyright http://shelvesetcomparer.codeplex.com. All Rights Reserved. This code released under the terms of the Microsoft Public License (MS-PL, http://opensource.org/licenses/ms-pl.html.) This is sample code only, do not use in production environments.</copyright>
+
+#if DEBUG
+
+// activate to get fake shelvest results with delay for debugging
+#define FakeShelvesetResult
+
+#endif
+
 using System;
 using System.Reflection;
 using System.Resources;

--- a/ShelvesetComparer/ShelvesetComparer.cs
+++ b/ShelvesetComparer/ShelvesetComparer.cs
@@ -42,6 +42,9 @@ namespace WiredTechSolutions.ShelvesetComparer
             }
 
             this.package = package;
+#if DEBUG
+            this.OutputPaneWriteLine("Loading ..");
+#endif
 
             OleMenuCommandService commandService = this.ServiceProvider.GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
             if (commandService != null)
@@ -54,6 +57,10 @@ namespace WiredTechSolutions.ShelvesetComparer
                 menuItem = new MenuCommand(this.ShelvesetComparerTeamExplorerViewIdMenuItemCallback, menuCommandID);
                 commandService.AddCommand(menuItem);
             }
+
+#if DEBUG
+            this.OutputPaneWriteLine("Loading finished.");
+#endif
         }
 
         /// <summary>
@@ -150,6 +157,33 @@ namespace WiredTechSolutions.ShelvesetComparer
             }
 
             return default(T);
+        }
+
+        public void OutputPaneWriteLine(string text, bool prefixDateTime = true)
+        {
+            IVsOutputWindow outWindow = GetService<SVsOutputWindow>() as IVsOutputWindow;
+            if (outWindow == null)
+            {
+                return;
+            }
+
+            // randomly generated GUID to identify the "Shelveset Comparer" output window pane
+            Guid paneGuid = new Guid("{38BFBA25-8AB3-4F8E-B992-930E403AA281}");
+            IVsOutputWindowPane generalPane = null;
+            outWindow.GetPane(ref paneGuid, out generalPane);
+            if (generalPane == null)
+            {
+                // the pane doesn't already exist
+                outWindow.CreatePane(ref paneGuid, WiredTechSolutions.ShelvesetComparer.Resources.ToolWindowTitle, Convert.ToInt32(true), Convert.ToInt32(true));
+                outWindow.GetPane(ref paneGuid, out generalPane);
+            }
+
+            if (prefixDateTime)
+            {
+                text = $"{DateTime.Now:G} {text}";
+            }
+            generalPane.OutputString(text + Environment.NewLine);
+            generalPane.Activate();
         }
     }
 }

--- a/ShelvesetComparer/ShelvesetComparer.csproj
+++ b/ShelvesetComparer/ShelvesetComparer.csproj
@@ -42,7 +42,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FakeShelvesetResult</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/ShelvesetComparer/ShelvesetComparerPackage.cs
+++ b/ShelvesetComparer/ShelvesetComparerPackage.cs
@@ -4,6 +4,8 @@ namespace WiredTechSolutions.ShelvesetComparer
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Runtime.InteropServices;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
 
@@ -24,14 +26,14 @@ namespace WiredTechSolutions.ShelvesetComparer
     /// To get loaded into VS, the package must be referred by &lt;Asset Type="Microsoft.VisualStudio.VsPackage" ...&gt; in .vsixmanifest file.
     /// </para>
     /// </remarks>
-    [PackageRegistration(UseManagedResourcesOnly = true)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)] // Info on this package for Help/About
     [Guid(ShelvesetComparerPackage.PackageGuidString)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideToolWindow(typeof(ShelvesetComparerToolWindow))]
     [ProvideAutoLoad(UIContextGuids80.NoSolution, PackageAutoLoadFlags.BackgroundLoad)] // load in the background
-    public sealed class ShelvesetComparerPackage : Package
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    public sealed class ShelvesetComparerPackage : AsyncPackage
     {
         /// <summary>
         /// ShelvesetComparerPackage GUID string.
@@ -55,10 +57,15 @@ namespace WiredTechSolutions.ShelvesetComparer
         /// Initialization of the package; this method is called right after the package is sited, so this is the place
         /// where you can put all the initialization code that rely on services provided by VisualStudio.
         /// </summary>
-        protected override void Initialize()
+        protected override async System.Threading.Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            base.Initialize();            
-            ShelvesetComparer.Initialize(this);
+            await base.InitializeAsync(cancellationToken, progress);
+            await JoinableTaskFactory.Run(async delegate {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                ShelvesetComparer.Initialize(this);
+                return System.Threading.Tasks.Task.FromResult<object>(null) ;
+            });
+            return;
         }
 
         #endregion

--- a/ShelvesetComparer/ShelvesetComparerPackage.cs
+++ b/ShelvesetComparer/ShelvesetComparerPackage.cs
@@ -31,7 +31,7 @@ namespace WiredTechSolutions.ShelvesetComparer
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideToolWindow(typeof(ShelvesetComparerToolWindow))]
-    //[ProvideAutoLoad(UIContextGuids80.NoSolution, PackageAutoLoadFlags.BackgroundLoad)] // load in the background, no auto load for now, load on first action
+    //[ProvideAutoLoad(UIContextGuids80.NoSolution, PackageAutoLoadFlags.BackgroundLoad)] // load in the background; no auto load for now. Package will load on first command
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     public sealed class ShelvesetComparerPackage : AsyncPackage
     {

--- a/ShelvesetComparer/ShelvesetComparerPackage.cs
+++ b/ShelvesetComparer/ShelvesetComparerPackage.cs
@@ -31,7 +31,7 @@ namespace WiredTechSolutions.ShelvesetComparer
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideToolWindow(typeof(ShelvesetComparerToolWindow))]
-    [ProvideAutoLoad(UIContextGuids80.NoSolution, PackageAutoLoadFlags.BackgroundLoad)] // load in the background
+    //[ProvideAutoLoad(UIContextGuids80.NoSolution, PackageAutoLoadFlags.BackgroundLoad)] // load in the background, no auto load for now, load on first action
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     public sealed class ShelvesetComparerPackage : AsyncPackage
     {

--- a/ShelvesetComparer/Source.extension.vsixmanifest
+++ b/ShelvesetComparer/Source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="d4c66e86-9fb7-4047-b964-2e216ae49a30" Version="1.0.1.19" Language="en-US" Publisher="Hamid Shahid" />
+        <Identity Id="d4c66e86-9fb7-4047-b964-2e216ae49a30" Version="1.0.2.19" Language="en-US" Publisher="Hamid Shahid" />
         <DisplayName>ShelvesetComparer</DisplayName>
         <Description xml:space="preserve">The extension allows you to compare files in two shelvesets.</Description>
         <License>Resources\License.rtf</License>

--- a/ShelvesetComparer/TeamExplorer/SelectShelvesetSection.cs
+++ b/ShelvesetComparer/TeamExplorer/SelectShelvesetSection.cs
@@ -4,8 +4,6 @@
 // This is sample code only, do not use in production environments.
 // </copyright>
 
-//#define FakeShelvesetResult // activate to get fake shelvest results with delay for debugging
-
 namespace WiredTechSolutions.ShelvesetComparer
 {
     using System;
@@ -255,7 +253,7 @@ namespace WiredTechSolutions.ShelvesetComparer
                     "Owner" + (idx % 2)));
             }
 
-            Task.Delay(1500); // for some time consuming operation, to show UI response
+            System.Threading.Thread.Sleep(1500); // for some time consuming operation, to show UI response
 
             return result;
         }

--- a/ShelvesetComparer/Views/SelectShelvesetTeamExplorerView.xaml.cs
+++ b/ShelvesetComparer/Views/SelectShelvesetTeamExplorerView.xaml.cs
@@ -168,7 +168,7 @@ namespace WiredTechSolutions.ShelvesetComparer
             }
             catch (Exception ex)
             {
-                this.OutputError(ex);
+                ShelvesetComparer.Instance?.OutputPaneWriteLine(ex.ToString());
 
                 this.ShowError(ex.Message);
             }
@@ -219,31 +219,6 @@ namespace WiredTechSolutions.ShelvesetComparer
         private static Shelveset CastAsShelveset(object listViewSelectedItem)
         {
             return (listViewSelectedItem as ShelvesetViewModel)?.Shelveset;
-        }
-
-        private void OutputError(Exception ex)
-        {
-            if (ShelvesetComparer.Instance == null)
-            {
-                // the package was not loaded
-                return;
-            }
-
-            IVsOutputWindow outWindow = ShelvesetComparer.Instance.GetService<SVsOutputWindow>() as IVsOutputWindow;
-
-            // randomly generated GUID to identify the "Shelveset Comparer" output window pane
-            Guid paneGuid = new Guid("{38BFBA25-8AB3-4F8E-B992-930E403AA281}");
-            IVsOutputWindowPane generalPane;
-            outWindow.GetPane(ref paneGuid, out generalPane);
-            if (generalPane == null)
-            {
-                // the pane doesn't already exist
-                outWindow.CreatePane(ref paneGuid, WiredTechSolutions.ShelvesetComparer.Resources.ToolWindowTitle, Convert.ToInt32(true), Convert.ToInt32(true));
-                outWindow.GetPane(ref paneGuid, out generalPane);
-            }
-
-            generalPane.OutputString(ex.ToString() + Environment.NewLine);
-            generalPane.Activate();
         }
     }
 }


### PR DESCRIPTION
This simply converts the package to an AsyncPackage which resolves the deprecated API warning: #13 
also increased assembly and VSIX version to 1.0.2.19

Temporary release can be found here: https://github.com/dprZoft/shelvesetcomparer/releases